### PR TITLE
Fix bug in parser

### DIFF
--- a/src/Data/CURL/CookieJar/Parser.hs
+++ b/src/Data/CURL/CookieJar/Parser.hs
@@ -44,7 +44,7 @@ cookieJarParser = createCookieJar <$> many' cookieParser
 -- field in the Cookie datatype
 cookieParser :: Parser Cookie
 cookieParser = 
-  skipSpace *> httpOnlyLine <|> commentLine <|> cookieLine
+  skipSpace *> (httpOnlyLine <|> commentLine <|> cookieLine)
   where
     httpOnlyLine = try $ "#HttpOnly_" *> cookieLineParser True
     commentLine = "#" *> skipWhile notEndOfLine *> endOfLine *> cookieParser


### PR DESCRIPTION
Fixes the parsing of files with empty lines by making sure we `skipSpace` always, not just before `httpOnlyLine`.